### PR TITLE
Include reference links in Oncoprint gene set track tooltips

### DIFF
--- a/portal/src/main/webapp/js/api/cbioportal-client.js
+++ b/portal/src/main/webapp/js/api/cbioportal-client.js
@@ -83,11 +83,19 @@ window.cbioportal_client = (function() {
 					}
 					return result;
 				}
+			},
+			'GenesetMetadata': {
+				endpoint: function (args) {
+					return ('api/genesets/fetch/');
+				},
+				args: function (args) {
+					return args.geneset_ids;
+				},
 			}
-		}
-		var ret = {};
+		};
+		var ret = {}, fn_name;
 		//legacy API
-		for (var fn_name in functionNameToEndpointProperties) {
+		for (fn_name in functionNameToEndpointProperties) {
 			if (functionNameToEndpointProperties.hasOwnProperty(fn_name)) {
 				ret['get'+fn_name] = (function(props) {
 					return function(args) {
@@ -97,7 +105,7 @@ window.cbioportal_client = (function() {
 			}
 		}
 		//new API
-		for (var fn_name in newApiFunctionNameToEndpointProperties) {
+		for (fn_name in newApiFunctionNameToEndpointProperties) {
 			if (newApiFunctionNameToEndpointProperties.hasOwnProperty(fn_name)) {
 				ret['get'+fn_name] = (function(props) {
 					return function(args) {
@@ -516,6 +524,7 @@ window.cbioportal_client = (function() {
 		getGenes: enforceRequiredArguments(makeOneIndexService('hugo_gene_symbols', function(d) { return d.hugo_gene_symbol;}, 'getGenes'), [[],["hugo_gene_symbols"]]),
 		getStudies: enforceRequiredArguments(makeOneIndexService('study_ids', function(d) { return d.id;}, 'getStudies'), [[], ["study_ids"]]),
 		getGenePanelsByPanelId: enforceRequiredArguments(makeOneIndexService('panel_id', function(d) { return d.stableId;}, 'getGenePanels'), [["panel_id"]]),
+		getGenesetMetadataByIds: enforceRequiredArguments(makeOneIndexService('geneset_ids', function(d) { return d.genesetId;}, 'getGenesetMetadata'), [["geneset_ids"]]),
 		getGeneticProfiles: enforceRequiredArguments(makeTwoIndexService('study_id', function(d) { return d.study_id;}, false, 'genetic_profile_ids', function(d) {return d.id; }, true, 'getGeneticProfiles'), [["study_id"],["genetic_profile_ids"]]),
 		getSampleLists: enforceRequiredArguments(makeTwoIndexService('study_id', function(d) { return d.study_id;}, false, 'sample_list_ids', function(d) {return d.id; }, true, 'getSampleLists'), [["study_id"], ["sample_list_ids"]]),
 		getSampleClinicalData: enforceRequiredArguments(makeHierIndexService(['study_id', 'attribute_ids', 'sample_ids'], ['study_id', 'attr_id', 'sample_id'], 'getSampleClinicalData'), [["study_id","attribute_ids"], ["study_id","attribute_ids","sample_ids"]]),

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1587,6 +1587,24 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 			fetch_promise.reject();
 		    });
 		}),
+	'getGenesetLinkMap': makeCachedPromiseFunction(
+		function (self, fetch_promise) {
+		    cbioportal_client.getGenesetMetadataByIds(
+			    {geneset_ids: self.getQueryGenesets()})
+		    .done(function (geneset_metadata) {
+			fetch_promise.resolve(
+				geneset_metadata.reduce(
+					function (link_map, metadatum) {
+					    var map_entry = {}
+					    map_entry[metadatum.genesetId] = metadatum.refLink;
+					    return $.extend(link_map, metadatum.refLink ? map_entry : {});
+					},
+					{}));
+		    })
+		    .fail(function () {
+			fetch_promise.reject();
+		    });
+		}),
 	'getGenesetGeneCorrelations': function(geneset_id) {
 	    var self = this;
 	    return this.getSelectedGsvaProfile()

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -1341,9 +1341,18 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	    'addGenesetTracks': function (genetic_profile_id, geneset_ids, geneset_link_map) {
 		oncoprint.suppressRendering();
 		var track_ids = [];
-		var i, track_geneset_id, track_params, new_track_id;
+		var i, track_geneset_id, track_params, new_track_id, track_label_obj;
 		for (i = 0; i < geneset_ids.length; i++) {
 		    track_geneset_id = geneset_ids[i];
+		    track_label_obj = new String(track_geneset_id);
+		    track_label_obj.html_content = (
+			    // encode the string as the textual contents of an
+			    // HTML element
+			    $('<div>').text(track_label_obj).html()
+			    // Include zero-width spaces to allow line breaks
+			    // after punctuation in (typically long) gs names
+			    .replace(/_/g, '_&#8203;')
+			    .replace(/\./g, '.&#8203;'));
 		    track_params = {
 			'rule_set_params': {
 			    'type': 'gradient',
@@ -1378,7 +1387,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			'track_label_color': 'grey',
 			'has_column_spacing': false,
 			'track_padding': 0,
-			'label': track_geneset_id,
+			'label': track_label_obj,
 			'target_group': this.GENESET_HEATMAP_TRACK_GROUP_INDEX,
 			'description': 'gene set scores from ' + genetic_profile_id,
 			'link_url': geneset_link_map[track_geneset_id],

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -1338,7 +1338,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 		    }
 		}));
 	    },
-	    'addGenesetTracks': function (genetic_profile_id, geneset_ids) {
+	    'addGenesetTracks': function (genetic_profile_id, geneset_ids, geneset_link_map) {
 		oncoprint.suppressRendering();
 		var track_ids = [];
 		var i, track_geneset_id, track_params, new_track_id;
@@ -1380,7 +1380,8 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			'track_padding': 0,
 			'label': track_geneset_id,
 			'target_group': this.GENESET_HEATMAP_TRACK_GROUP_INDEX,
-			'description': track_geneset_id + ' gene set scores from ' + genetic_profile_id,
+			'description': 'gene set scores from ' + genetic_profile_id,
+			'link_url': geneset_link_map[track_geneset_id],
 			'removeCallback': makeRemoveGenesetTrackHandler(track_geneset_id),
 			'expandCallback': makeGenesetExpandHandler(track_geneset_id),
 			'expandButtonTextGetter': function (is_expanded) {
@@ -1847,10 +1848,12 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	}).then(function () {
 	    var queried_gene_sets = QuerySession.getQueryGenesets();
 	    if (queried_gene_sets !== null && queried_gene_sets.length > 0) {
-		return QuerySession.getSelectedGsvaProfile()
-		.then(function (gsva_profile) {
+		return $.when(
+			QuerySession.getSelectedGsvaProfile(),
+			QuerySession.getGenesetLinkMap())
+		.then(function (gsva_profile, geneset_link_map) {
 		    console.log("in initOncoprint, adding gene set tracks");
-		    State.addGenesetTracks(gsva_profile.id, queried_gene_sets);
+		    State.addGenesetTracks(gsva_profile.id, queried_gene_sets, geneset_link_map);
 		});
 	    } else {
 		// nothing to do for gene set tracks; return a resolved promise

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1683,7 +1683,7 @@ var OncoprintLabelView = (function () {
 		    var previous_track_id = getLabelAboveMouseSpace(view, track_group, evt.offsetY, view.dragged_label_track_id);
 		    stopDragging(view, previous_track_id);
 		}
-		view.tooltip.hide();
+		view.tooltip.hideIfNotAlreadyGoingTo(150);
 	    });
 	})(this);
 	

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1659,11 +1659,11 @@ var OncoprintLabelView = (function () {
 			var $tooltip_div = $('<div>');
 			var offset = view.$canvas.offset();   
 			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])) {
-			    $tooltip_div.append($('<b>'+view.labels[hovered_track]+'</b>'));
+			    $tooltip_div.append($('<b>').text(view.labels[hovered_track]));
 			}
-			var track_description = view.track_descriptions[hovered_track].replace("<", "&lt;").replace(">", "&gt;");
+			var track_description = view.track_descriptions[hovered_track];
 			if (track_description.length > 0) {
-			    $tooltip_div.append(track_description + "<br>");
+			    $tooltip_div.append($('<div>').text(track_description));
 			}
 			if (model.getContainingTrackGroup(hovered_track).length > 1) {
 			    view.$canvas.css('cursor', 'move');

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1620,6 +1620,7 @@ var OncoprintLabelView = (function () {
 	this.label_middles_view_space = {};
 	this.labels = {};
 	this.label_colors = {};
+	this.track_link_urls = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -1658,8 +1659,11 @@ var OncoprintLabelView = (function () {
 		    if (hovered_track !== null) {
 			var $tooltip_div = $('<div>');
 			var offset = view.$canvas.offset();   
-			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])) {
-			    $tooltip_div.append($('<b>').text(view.labels[hovered_track]));
+			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])
+				|| view.track_link_urls[hovered_track]) {
+			    $tooltip_div.append(formatTooltipHeader(
+				    view.labels[hovered_track],
+				    view.track_link_urls[hovered_track]));
 			}
 			var track_description = view.track_descriptions[hovered_track];
 			if (track_description.length > 0) {
@@ -1744,6 +1748,18 @@ var OncoprintLabelView = (function () {
 	} else {
 	    return label;
 	}
+    };
+    var formatTooltipHeader = function (label, link_url) {
+	var header_contents;
+	if (link_url) {
+	    header_contents = (
+		    $('<a target="_blank" rel="noopener noreferrer">')
+		    .attr('href', link_url)
+		    .text(label));
+	} else {
+	    header_contents = document.createTextNode(label);
+	}
+	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {
 	if (view.rendering_suppressed) {
@@ -1884,6 +1900,7 @@ var OncoprintLabelView = (function () {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
 	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
+	    this.track_link_urls[track_ids[i]] = model.getTrackLinkUrl(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);
@@ -3211,6 +3228,7 @@ var OncoprintModel = (function () {
 	// Track Properties
 	this.track_label = {};
 	this.track_label_color = {};
+	this.track_link_url = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -3756,7 +3774,7 @@ var OncoprintModel = (function () {
 	    var params = params_list[i];
 	    addTrack(this, params.track_id, params.target_group, params.track_group_header,
 		    params.cell_height, params.track_padding, params.has_column_spacing,
-		    params.data_id_key, params.tooltipFn,
+		    params.data_id_key, params.tooltipFn, params.link_url,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
 		    params.data, params.rule_set, params.track_label_color, params.expansion_of,
@@ -3767,13 +3785,14 @@ var OncoprintModel = (function () {
   
     var addTrack = function (model, track_id, target_group, track_group_header,
 	    cell_height, track_padding, has_column_spacing,
-	    data_id_key, tooltipFn,
+	    data_id_key, tooltipFn, link_url,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
 	    data, rule_set, track_label_color, expansion_of, expandCallback,
 	    expandButtonTextGetter) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
+	model.track_link_url[track_id] = ifndef(link_url, null);
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -3880,6 +3899,7 @@ var OncoprintModel = (function () {
 	delete this.track_data[track_id];
 	delete this.track_rule_set_id[track_id];
 	delete this.track_label[track_id];
+	delete this.track_link_url[track_id];
 	delete this.cell_height[track_id];
 	delete this.track_padding[track_id];
 	delete this.track_data_id_key[track_id];
@@ -4103,6 +4123,10 @@ var OncoprintModel = (function () {
     
     OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
 	return this.track_label_color[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLinkUrl = function (track_id) {
+	return this.track_link_url[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1754,11 +1754,11 @@ var OncoprintLabelView = (function () {
 	if (link_url) {
 	    header_contents = (
 		    $('<a target="_blank" rel="noopener noreferrer">')
-		    .attr('href', link_url)
-		    .text(label));
+		    .attr('href', link_url));
 	} else {
-	    header_contents = document.createTextNode(label);
+	    header_contents = $('<span>');
 	}
+	header_contents.append(label.html_content || document.createTextNode(label));
 	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -19,6 +19,7 @@ var OncoprintLabelView = (function () {
 	this.label_middles_view_space = {};
 	this.labels = {};
 	this.label_colors = {};
+	this.track_link_urls = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -57,8 +58,11 @@ var OncoprintLabelView = (function () {
 		    if (hovered_track !== null) {
 			var $tooltip_div = $('<div>');
 			var offset = view.$canvas.offset();   
-			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])) {
-			    $tooltip_div.append($('<b>').text(view.labels[hovered_track]));
+			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])
+				|| view.track_link_urls[hovered_track]) {
+			    $tooltip_div.append(formatTooltipHeader(
+				    view.labels[hovered_track],
+				    view.track_link_urls[hovered_track]));
 			}
 			var track_description = view.track_descriptions[hovered_track];
 			if (track_description.length > 0) {
@@ -143,6 +147,18 @@ var OncoprintLabelView = (function () {
 	} else {
 	    return label;
 	}
+    };
+    var formatTooltipHeader = function (label, link_url) {
+	var header_contents;
+	if (link_url) {
+	    header_contents = (
+		    $('<a target="_blank" rel="noopener noreferrer">')
+		    .attr('href', link_url)
+		    .text(label));
+	} else {
+	    header_contents = document.createTextNode(label);
+	}
+	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {
 	if (view.rendering_suppressed) {
@@ -283,6 +299,7 @@ var OncoprintLabelView = (function () {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
 	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
+	    this.track_link_urls[track_ids[i]] = model.getTrackLinkUrl(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -58,11 +58,11 @@ var OncoprintLabelView = (function () {
 			var $tooltip_div = $('<div>');
 			var offset = view.$canvas.offset();   
 			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])) {
-			    $tooltip_div.append($('<b>'+view.labels[hovered_track]+'</b>'));
+			    $tooltip_div.append($('<b>').text(view.labels[hovered_track]));
 			}
-			var track_description = view.track_descriptions[hovered_track].replace("<", "&lt;").replace(">", "&gt;");
+			var track_description = view.track_descriptions[hovered_track];
 			if (track_description.length > 0) {
-			    $tooltip_div.append(track_description + "<br>");
+			    $tooltip_div.append($('<div>').text(track_description));
 			}
 			if (model.getContainingTrackGroup(hovered_track).length > 1) {
 			    view.$canvas.css('cursor', 'move');

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -153,11 +153,11 @@ var OncoprintLabelView = (function () {
 	if (link_url) {
 	    header_contents = (
 		    $('<a target="_blank" rel="noopener noreferrer">')
-		    .attr('href', link_url)
-		    .text(label));
+		    .attr('href', link_url));
 	} else {
-	    header_contents = document.createTextNode(label);
+	    header_contents = $('<span>');
 	}
+	header_contents.append(label.html_content || document.createTextNode(label));
 	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -82,7 +82,7 @@ var OncoprintLabelView = (function () {
 		    var previous_track_id = getLabelAboveMouseSpace(view, track_group, evt.offsetY, view.dragged_label_track_id);
 		    stopDragging(view, previous_track_id);
 		}
-		view.tooltip.hide();
+		view.tooltip.hideIfNotAlreadyGoingTo(150);
 	    });
 	})(this);
 	

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
@@ -130,6 +130,7 @@ var OncoprintModel = (function () {
 	// Track Properties
 	this.track_label = {};
 	this.track_label_color = {};
+	this.track_link_url = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -675,7 +676,7 @@ var OncoprintModel = (function () {
 	    var params = params_list[i];
 	    addTrack(this, params.track_id, params.target_group, params.track_group_header,
 		    params.cell_height, params.track_padding, params.has_column_spacing,
-		    params.data_id_key, params.tooltipFn,
+		    params.data_id_key, params.tooltipFn, params.link_url,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
 		    params.data, params.rule_set, params.track_label_color, params.expansion_of,
@@ -686,13 +687,14 @@ var OncoprintModel = (function () {
   
     var addTrack = function (model, track_id, target_group, track_group_header,
 	    cell_height, track_padding, has_column_spacing,
-	    data_id_key, tooltipFn,
+	    data_id_key, tooltipFn, link_url,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
 	    data, rule_set, track_label_color, expansion_of, expandCallback,
 	    expandButtonTextGetter) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
+	model.track_link_url[track_id] = ifndef(link_url, null);
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -799,6 +801,7 @@ var OncoprintModel = (function () {
 	delete this.track_data[track_id];
 	delete this.track_rule_set_id[track_id];
 	delete this.track_label[track_id];
+	delete this.track_link_url[track_id];
 	delete this.cell_height[track_id];
 	delete this.track_padding[track_id];
 	delete this.track_data_id_key[track_id];
@@ -1022,6 +1025,10 @@ var OncoprintModel = (function () {
     
     OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
 	return this.track_label_color[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLinkUrl = function (track_id) {
+	return this.track_link_url[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/service/src/main/java/org/cbioportal/service/GenesetService.java
+++ b/service/src/main/java/org/cbioportal/service/GenesetService.java
@@ -14,8 +14,10 @@ public interface GenesetService {
     BaseMeta getMetaGenesets();
 
     Geneset getGeneset(String genesetId) throws GenesetNotFoundException;
-    
+
     List<Gene> getGenesByGenesetId(String genesetId) throws GenesetNotFoundException;
+
+    List<Geneset> fetchGenesets(List<String> genesetIds);
 
 }
 

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetServiceImpl.java
@@ -47,4 +47,10 @@ public class GenesetServiceImpl implements GenesetService {
 	    this.getGeneset(genesetId);
 		return genesetRepository.getGenesByGenesetId(genesetId);
 	}
+
+    @Override
+    public List<Geneset> fetchGenesets(List<String> genesetIds) {
+        return genesetRepository.fetchGenesets(genesetIds);
+    }
+
 }

--- a/web/src/main/java/org/cbioportal/web/GenesetController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
 
 import org.cbioportal.model.Geneset;
 import org.cbioportal.service.GenesetService;
@@ -19,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -70,5 +72,16 @@ public class GenesetController {
         return new ResponseEntity<>(genesetService.getGeneset(genesetId), HttpStatus.OK);
     }
 
+    @RequestMapping(value = "/genesets/fetch", method = RequestMethod.POST,
+            consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch gene sets by ID")
+    public ResponseEntity<List<Geneset>> fetchGenesets(
+            @ApiParam(required = true, value = "List of gene set IDs")
+            @Size(min = 1)
+            @RequestBody List<String> genesetIds) {
+        return new ResponseEntity<>(
+                genesetService.fetchGenesets(genesetIds),
+                HttpStatus.OK);
+    }
 
 }


### PR DESCRIPTION
When exploring the relevance of gene sets through the heatmap functionality in the Oncoprint, users sometimes want to look up what a gene set is actually about. The metadata known to cBioPortal include the URL of the main reference for the gene set. By making the Oncoprint setup retrieve this URL via the web API, a hyperlink can be presented to the user in the track tooltip.

## Screenshot ##
![Screenshot of an Oncoprint track tooltip with a link as the header](https://user-images.githubusercontent.com/4929431/28020684-8ccf0944-6585-11e7-9725-0e397fb4d09e.png)


## Superseded screenshot of pre-review version ##
![Screenshot of an Oncoprint track tooltip with a link in the description](https://user-images.githubusercontent.com/4929431/27872112-f8161918-61a7-11e7-93b9-905bd1d20ceb.png)