### PR TITLE
Fix FTP URLs; update mysql steps

### DIFF
--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -4,7 +4,7 @@ The next step is to populate your cBioPortal instance with all the required back
 
 ## Download the cBioPortal Seed Database
 
-A cBioPortal seed database for human can be found on [the datahub page](https://github.com/cBioPortal/datahub/blob/84fd66daf8325ad9721895d1cc503653686de15e/seedDB/README.md). If you are looking for mouse, check [this link](https://github.com/cBioPortal/datahub/blob/b02ac7037c8febeb86d6635602fc98327fb77c50/seedDB_mouse/README.md).
+A cBioPortal seed database for human can be found on [the datahub page](https://github.com/cBioPortal/datahub/blob/master/seedDB/README.md). If you are looking for mouse, check [this link](https://github.com/cBioPortal/datahub/blob/master/seedDB_mouse/README.md).
 
 After download, the files can be unzipped by entering the following command:
 
@@ -12,7 +12,7 @@ After download, the files can be unzipped by entering the following command:
 
 ## Import the cBioPortal Seed Database
 
-*Important:* Before importing, make sure that you have [followed the pre-build steps](Pre-Build-Steps.md) for creating the `cbioportal` database (see section "Create the cBioPortal MySQL Databases and User").
+**Important:** Before importing, make sure that you have [followed the pre-build steps](Pre-Build-Steps.md) for creating the `cbioportal` database (see section "Create the cBioPortal MySQL Databases and User").
 
 1. Import the database schema:
 
@@ -20,26 +20,22 @@ After download, the files can be unzipped by entering the following command:
     mysql --user=cbio_user --password=somepassword cbioportal < cgds.sql
     ```
 
-For human, then you should execute these two commands (the last command takes a bit longer to import PDB data that will enable the visualization of PDB structures in the mutation tab):
+2. Import the main part of the seed database:
 
-    > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_hg19_vX.Y.Z.sql
-    
-    > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_only-pdb.sql
-    
-For mouse, you just need to execute one command (PDB tables are not supported in mouse):
+    ```
+    mysql --user=cbio_user --password=somepassword cbioportal < seed-cbioportal_RefGenome_vX.Y.Z.sql
+    ```
 
-    > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_mm10_vX.Y.Z.sql
+    **Important:** Replace `seed-cbioportal_RefGenome_vX.Y.Z.sql` with the downloaded version of the seed database, such as `seed-cbioportal_hg19_v2.3.1.sql` or `seed-cbioportal_mm10_v2.3.1.sql`.
 
-*Important:* Replace `seed-cbioportal_hg19_vX.Y.Z.sql` with the downloaded version of the seed database, such as `seed-cbioportal_hg19_v2.1.0.sql` (human) or `seed-cbioportal_mm10_v2.1.0.sql` (mouse).
-
-3. Import the protein database (PDB) part of the seed database. This will enable the visualization of PDB structures in the mutation tab. Loading this file takes more time than loading the previous files, and is optional for users that do not require PDB structures.
+3. (Human only) Import the Protein Data Bank (PDB) part of the seed database. This will enable the visualization of PDB structures in the mutation tab. Loading this file takes more time than loading the previous files, and is optional for users that do not require PDB structures.
 
     ```
     mysql --user=cbio_user --password=somepassword cbioportal < seed-cbioportal_hg19_vX.Y.Z_only-pdb.sql
     ```
-    *Important:* Replace `seed-cbioportal_hg19_vX.Y.Z_only-pdb.sql` with the downloaded version of the PDB database, such as `seed-cbioportal_hg19_v2.1.0_only-pdb.sql`.
+    **Important:** Replace `seed-cbioportal_hg19_vX.Y.Z_only-pdb.sql` with the downloaded version of the PDB database, such as `seed-cbioportal_hg19_v2.3.1_only-pdb.sql`.
 
-:information_source: Please be aware of the version of the seed database. In the [README on datahub](https://github.com/cbioportal/datahub/blob/master/seedDB/README.md), we stated which version of cBioPortal is compatible with the current seed database.
+**Important:** Please be aware of the version of the seed database. In the [README on datahub](https://github.com/cbioportal/datahub/blob/master/seedDB/README.md), we stated which version of cBioPortal is compatible with the current seed database.
 
 If the database is older than what cBioPortal is expecting, the system will ask you (during startup or data loading) to migrate the database to a newer version. The migration process is described [here](Updating-your-cBioPortal-installation.md#running-the-migration-script).
 

--- a/docs/Updating-gene-and-gene_alias-tables.md
+++ b/docs/Updating-gene-and-gene_alias-tables.md
@@ -1,28 +1,27 @@
+# Updating the gene names and aliases tables
 This manual is intended for users that have knowledge about the structure of the cBioPortal seed database.
 
-When loading studies into cBioPortal it is possible for warnings to occur that are caused by an outdated seed database. Gene symbols can be deprecated or be assigned to a different Entrez Gene in a new release. Also Entrez Gene IDs can be added. This markdown explains how to update the seed database, in order to use the most recent Entrez Gene IDs. 
+When loading studies into cBioPortal it is possible for warnings to occur that are caused by an outdated seed database. Gene symbols can be deprecated or be assigned to a different Entrez Gene in a new release. Also Entrez Gene IDs can be added. This markdown explains how to update the seed database, in order to use the most recent Entrez Gene IDs.
 
-The cBioPortal scripts package provides a method to update the `gene` and `gene_alias` tables. This requires the latest version of the NCBI Gene Info: [click here for human](ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz) and [here for mouse](ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Mus_musculus.gene_info.gz).
+The cBioPortal scripts package provides a method to update the `gene` and `gene_alias` tables. This requires the latest version of the NCBI Gene Info.
 
-## Updating the gene names and aliases
+### Human genes
+Homo_sapien.gene_info.gz\
+ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz
 
+### Mouse genes
+Mus_musculus.gene_info.gz\
+ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Mus_musculus.gene_info.gz
+
+## MySQL steps
 Execute these steps in case you want to reset your database to the most recent genes list from NCBI.
 
-1- Remove all studies from your installation. You can use the [study removal tool](Development%2C-debugging-and-maintenance-mode-using-cbioportalImporter#deleting-a-study). Also empty tables `mutation_event` and `cna_event`
-```sql
-TRUNCATE TABLE mutation_event;
-TRUNCATE TABLE cna_event;
-```
-
-Another way of obtaining an empty database is starting a new MySQL database with the previous seed database.
+1- Start a new MySQL database with the previous seed database, which can be found on cBioPortal Datahub for [human](https://github.com/cBioPortal/datahub/tree/master/seedDB) and [mouse](https://github.com/cBioPortal/datahub/tree/master/seedDB_mouse).
 
 2- If DB engine supports foreign key (FK) constraints, e.g. InnoDB, drop constraints:
 ```sql
 ALTER TABLE cosmic_mutation
   DROP FOREIGN KEY cosmic_mutation_ibfk_1;
-
-ALTER TABLE sanger_cancer_census
-  DROP FOREIGN KEY sanger_cancer_census_ibfk_1;
 
 ALTER TABLE uniprot_id_mapping
   DROP FOREIGN KEY uniprot_id_mapping_ibfk_1;
@@ -31,7 +30,7 @@ ALTER TABLE uniprot_id_mapping
 3- Empty tables `gene` and `gene_alias`
 ```sql
 TRUNCATE TABLE gene_alias;
-TRUNCATE TABLE gene;
+delete from gene;
 ```
 
 4- Restart cBioPortal (restart webserver) to clean-up any cached gene lists.
@@ -41,13 +40,16 @@ TRUNCATE TABLE gene;
 After downloading, go to your downloads directory, decompress the file and add it as an argument (--gtf) in the next step.
 
 6- To import gene data type the following commands when in the folder `<your_cbioportal_dir>/core/src/main/scripts`:
-
 ```
  export PORTAL_HOME=<your_cbioportal_dir>
-./importGenes.pl --genes <ncbi_gene_info.txt> --gtf <gencode.v25.annotation.gtf>
+./importGenes.pl --genes <ncbi_species.gene_info> --gtf <gencode.v25.annotation.gtf>
 ```
 
 7- :warning: Check the `gene` and `gene_alias` tables to verify that they are filled correctly.
+```sql
+SELECT count(*) FROM cbioportal.gene;
+SELECT count(*) FROM cbioportal.gene_alias;
+```
 
 8- Additionally, there are several other tables you may want to update now (only in human).
 
@@ -70,11 +72,8 @@ commit;
 10- If DB engine supports FK constraints, e.g. InnoDB, restore constraints:
 ```sql
 ALTER TABLE cosmic_mutation
-  ADD FOREIGN KEY (`ENTREZ_GENE_ID`) REFERENCES `gene` (`ENTREZ_GENE_ID`);
-
-ALTER TABLE sanger_cancer_census
-  ADD FOREIGN KEY (`ENTREZ_GENE_ID`) REFERENCES `gene` (`ENTREZ_GENE_ID`);
+  ADD CONSTRAINT cosmic_mutation_ibfk_1 FOREIGN KEY (`ENTREZ_GENE_ID`) REFERENCES `gene` (`ENTREZ_GENE_ID`);
 
 ALTER TABLE uniprot_id_mapping
-  ADD FOREIGN KEY (`ENTREZ_GENE_ID`) REFERENCES `gene` (`ENTREZ_GENE_ID`);
+  ADD CONSTRAINT uniprot_id_mapping_ibfk_1 FOREIGN KEY (`ENTREZ_GENE_ID`) REFERENCES `gene` (`ENTREZ_GENE_ID`);
 ```


### PR DESCRIPTION
- Change download of seed database URLs to `master` on Datahub. The READMEs on `master` now contain links to previous seed database(s).
- FTP links did not work in GitHub Markdown, so I changed these to full URLs.
- For updating the gene and aliases tables, additional (required) steps are added.
- Specify names of foreign keys that are created.
