### PR TITLE
New webservices which retrieves amount of clinical attributes for patients or samples in a study

### DIFF
--- a/business/src/main/java/org/mskcc/cbio/portal/model/DBClinicalFieldWithStats.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/model/DBClinicalFieldWithStats.java
@@ -1,0 +1,22 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.mskcc.cbio.portal.model;
+
+import java.io.Serializable;
+
+/**
+ *
+ * @author dionnezaal
+ */
+public class DBClinicalFieldWithStats implements Serializable {
+    public String attr_id;
+    public String display_name;
+    public String description;
+    public String datatype;
+    public String is_patient_attribute;
+    public String priority;
+    public Integer attribute_count;
+}

--- a/business/src/main/java/org/mskcc/cbio/portal/persistence/ClinicalFieldMapper.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/persistence/ClinicalFieldMapper.java
@@ -4,6 +4,7 @@ package org.mskcc.cbio.portal.persistence;
 import java.util.List;
 import org.apache.ibatis.annotations.Param;
 import org.mskcc.cbio.portal.model.DBClinicalField;
+import org.mskcc.cbio.portal.model.DBClinicalFieldWithStats;
 
 /*
  * To change this license header, choose License Headers in Project Properties.
@@ -30,4 +31,8 @@ public interface ClinicalFieldMapper {
 	List<DBClinicalField> getAllClinicalFields();
    List<DBClinicalField> getAllClinicalFieldsByStudy(@Param("study_id") Integer study_id);
 	List<DBClinicalField> getClinicalFieldsById(@Param("attr_ids") List<String> attr_ids);
+    
+    List<DBClinicalFieldWithStats> getSampleClinicalFieldsByStudyWithStats(@Param("study_id") Integer study_id);
+    List<DBClinicalFieldWithStats> getPatientClinicalFieldsByStudyWithStats(@Param("study_id") Integer study_id);
+    
 }

--- a/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
@@ -16,6 +16,7 @@ import org.mskcc.cbio.portal.model.AltCount;
 import org.mskcc.cbio.portal.model.DBAltCountInput;
 import org.mskcc.cbio.portal.model.DBCancerType;
 import org.mskcc.cbio.portal.model.DBClinicalField;
+import org.mskcc.cbio.portal.model.DBClinicalFieldWithStats;
 import org.mskcc.cbio.portal.model.DBClinicalPatientData;
 import org.mskcc.cbio.portal.model.DBClinicalSampleData;
 import org.mskcc.cbio.portal.model.DBGene;
@@ -556,5 +557,32 @@ public class ApiService {
 	public List<DBStudy> getStudies(List<String> study_ids) {
 		return studyMapperLegacy.getStudies(study_ids);
 	}
-
+    
+    
+    @Transactional
+    @PreAuthorize("hasPermission(#study_id, 'CancerStudy', 'read')")
+    public List<DBClinicalFieldWithStats> getSampleClinicalAttributesWithStats(String study_id) {
+        List<String> study_ids = new LinkedList<>();
+        study_ids.add(study_id);
+        List<DBStudy> studies = studyMapperLegacy.getStudies(study_ids);
+        if (studies.size() > 0) {
+            return clinicalFieldMapper.getSampleClinicalFieldsByStudyWithStats(studies.get(0).internal_id);
+        } else {
+            return new LinkedList<>();
+        }
+    }
+    
+    @Transactional
+    @PreAuthorize("hasPermission(#study_id, 'CancerStudy', 'read')")
+    public List<DBClinicalFieldWithStats> getPatientClinicalAttributesWithStats(String study_id) {
+        List<String> study_ids = new LinkedList<>();
+        study_ids.add(study_id);
+        List<DBStudy> studies = studyMapperLegacy.getStudies(study_ids);
+        if (studies.size() > 0) {
+            return clinicalFieldMapper.getPatientClinicalFieldsByStudyWithStats(studies.get(0).internal_id);
+        } else {
+            return new LinkedList<>();
+        }
+    }
+    
 }

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/ClinicalFieldMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/ClinicalFieldMapper.xml
@@ -12,6 +12,16 @@
     <result property="priority" column="PRIORITY"/>
 </resultMap>
 
+<resultMap id="ClinicalFieldResultWithStats" type="DBClinicalFieldWithStats">
+    <id property="attr_id" column="ATTR_ID"/>
+    <result property="display_name" column="DISPLAY_NAME"/>
+    <result property="description" column="DESCRIPTION"/>
+    <result property="datatype" column="DATATYPE"/>
+    <result property="is_patient_attribute" column="PATIENT_ATTRIBUTE"/>
+    <result property="priority" column="PRIORITY"/>
+    <result property="attribute_count" column="ATTRIBUTE_COUNT"/>
+</resultMap>
+
 <select id="getSampleClinicalFieldsByStudy" resultMap="ClinicalFieldResult">
     select clinical_attribute_meta.ATTR_ID,clinical_attribute_meta.DISPLAY_NAME,clinical_attribute_meta.DESCRIPTION,clinical_attribute_meta.DATATYPE,clinical_attribute_meta.PATIENT_ATTRIBUTE,clinical_attribute_meta.PRIORITY from clinical_attribute_meta
     where clinical_attribute_meta.CANCER_STUDY_ID=#{study_id} and clinical_attribute_meta.PATIENT_ATTRIBUTE=0    
@@ -60,8 +70,6 @@
     select * from clinical_attribute_meta where PATIENT_ATTRIBUTE=1
 </select>
 
-
-
 <select id="getClinicalFieldsById" resultMap="ClinicalFieldResult">
     select clinical_attribute_meta.ATTR_ID,clinical_attribute_meta.DISPLAY_NAME,clinical_attribute_meta.DESCRIPTION,clinical_attribute_meta.DATATYPE,clinical_attribute_meta.PATIENT_ATTRIBUTE,clinical_attribute_meta.PRIORITY from clinical_attribute_meta
     where clinical_attribute_meta.ATTR_ID in <foreach item="item" collection="attr_ids" open="(" separator="," close=")">#{item}</foreach>
@@ -69,6 +77,23 @@
 
 <select id="getAllClinicalFields" resultMap="ClinicalFieldResult">
     select * from clinical_attribute_meta
+</select>
+
+<select id="getSampleClinicalFieldsByStudyWithStats" resultMap="ClinicalFieldResultWithStats">
+    select clinical_attribute_meta.ATTR_ID,clinical_attribute_meta.DISPLAY_NAME,clinical_attribute_meta.DESCRIPTION,clinical_attribute_meta.DATATYPE,clinical_attribute_meta.PATIENT_ATTRIBUTE,clinical_attribute_meta.PRIORITY, COUNT(patient.INTERNAL_ID) AS ATTRIBUTE_COUNT from clinical_attribute_meta
+    left join clinical_sample on clinical_attribute_meta.ATTR_ID = clinical_sample.ATTR_ID
+    left join sample on clinical_sample.INTERNAL_ID = sample.INTERNAL_ID
+    left join patient on sample.PATIENT_ID = patient.INTERNAL_ID and patient.CANCER_STUDY_ID=#{study_id}
+    where clinical_attribute_meta.CANCER_STUDY_ID=#{study_id} and clinical_attribute_meta.PATIENT_ATTRIBUTE=0
+    group by clinical_attribute_meta.ATTR_ID
+</select>
+
+<select id="getPatientClinicalFieldsByStudyWithStats" resultMap="ClinicalFieldResultWithStats">
+    select clinical_attribute_meta.ATTR_ID,clinical_attribute_meta.DISPLAY_NAME,clinical_attribute_meta.DESCRIPTION,clinical_attribute_meta.DATATYPE,clinical_attribute_meta.PATIENT_ATTRIBUTE,clinical_attribute_meta.PRIORITY, COUNT(patient.INTERNAL_ID) AS ATTRIBUTE_COUNT from clinical_attribute_meta
+    left join clinical_patient ON clinical_attribute_meta.ATTR_ID = clinical_patient.ATTR_ID
+    left join patient on clinical_patient.INTERNAL_ID = patient.INTERNAL_ID and patient.CANCER_STUDY_ID=#{study_id}
+    where clinical_attribute_meta.PATIENT_ATTRIBUTE = 1 and clinical_attribute_meta.CANCER_STUDY_ID=#{study_id}
+    group by clinical_attribute_meta.ATTR_ID
 </select>
         
 </mapper>

--- a/web/src/main/java/org/cbioportal/weblegacy/ApiController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/ApiController.java
@@ -12,6 +12,7 @@ import org.mskcc.cbio.portal.model.CosmicCount;
 import org.mskcc.cbio.portal.service.ApiService;
 import org.mskcc.cbio.portal.model.DBCancerType;
 import org.mskcc.cbio.portal.model.DBClinicalField;
+import org.mskcc.cbio.portal.model.DBClinicalFieldWithStats;
 import org.mskcc.cbio.portal.model.DBClinicalPatientData;
 import org.mskcc.cbio.portal.model.DBClinicalSampleData;
 import org.mskcc.cbio.portal.model.DBGene;
@@ -372,5 +373,29 @@ public class ApiController {
         } else {
             return service.getStudies(study_ids);
         }
+    }
+    
+    @ApiOperation(value = "Get clinical attribute identifiers, filtered by sample, including stats of attributes",
+                  nickname = "getSampleClinicalAttributesWithStats",
+                  notes = "")
+    @Transactional
+    @RequestMapping(value = "/clinicalattributes/sampleswithstats", method = {RequestMethod.GET, RequestMethod.POST})
+    public @ResponseBody List<DBClinicalFieldWithStats> getSampleClinicalAttributesWithStats(
+               @ApiParam(value = "A single study id, such as those returned by /api/studies. (example: brca_tcga). Empty string returns clinical attributes across all studies.")
+               @RequestParam(required = true)
+               String study_id) {
+            return service.getSampleClinicalAttributesWithStats(study_id);
+    }
+    
+    @ApiOperation(value = "Get clinical attribute identifiers, filtered by patient, including stats of attributes",
+                  nickname = "getPatientClinicalAttributesWithStats",
+                  notes = "")
+    @Transactional
+    @RequestMapping(value = "/clinicalattributes/patientswithstats", method = {RequestMethod.GET, RequestMethod.POST})
+    public @ResponseBody List<DBClinicalFieldWithStats> getPatientClinicalAttributesWithStats(
+             @ApiParam(value = "A single study id, such as those returned by /api/studies. (example: brca_tcga). Empty string returns clinical attributes across all studies.")
+             @RequestParam(required = true)
+                  String study_id) {
+        return service.getPatientClinicalAttributesWithStats(study_id);
     }
 }


### PR DESCRIPTION
Two new webservices were added to the api-legacy to retrieve the amount of samples or patients that have a certain clinical attribute in a study. Separate webservices were made for patients and samples, because the clinical track dropdown menu in the oncoprint retrieves them separatly. The webservices are based on current api-legacy clinicalattributes/samples and clinicalattributes/patients and were extended by adding the attribute_count to the response.